### PR TITLE
Potential fix for code scanning alert no. 38: Incomplete URL substring sanitization

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1161,8 +1161,18 @@ class DashboardHandler {
         const hasScriptSrc = cspContent.includes('script-src');
         const hasStyleSrc = cspContent.includes('style-src');
         const hasConnectSrc = cspContent.includes('connect-src');
-        const hasFirebaseDomains = cspContent.includes('firebase.googleapis.com') || cspContent.includes('firestore.googleapis.com');
-        const hasGoogleDomains = cspContent.includes('googleapis.com');
+        const allowedDomains = ['firebase.googleapis.com', 'firestore.googleapis.com', 'googleapis.com'];
+
+        const parseCSP = (csp) => {
+            const directives = csp.split(';').map(d => d.trim());
+            const connectSrcDirective = directives.find(d => d.startsWith('connect-src'));
+            return connectSrcDirective ? connectSrcDirective.split(' ').slice(1) : [];
+        };
+
+        const cspDomains = parseCSP(cspContent);
+        const hasFirebaseDomains = allowedDomains.includes('firebase.googleapis.com') && cspDomains.includes('firebase.googleapis.com') ||
+                                   allowedDomains.includes('firestore.googleapis.com') && cspDomains.includes('firestore.googleapis.com');
+        const hasGoogleDomains = allowedDomains.includes('googleapis.com') && cspDomains.includes('googleapis.com');
         const hasUnsafeInline = cspContent.includes("'unsafe-inline'");
 
         let score = 0;


### PR DESCRIPTION
Potential fix for [https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/38](https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/38)

The fix involves parsing the CSP content properly to extract and validate the domains explicitly listed in the `connect-src` or other relevant CSP directives. Instead of checking for substrings, the CSP should be parsed to ensure that the domains match exactly against a predefined list of allowed domains.

To implement this, we can use a library such as `url-parse` or write a simple parser to extract and validate the policy directives. This ensures that we only allow exact domain matches rather than relying on substring checks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
