### PR TITLE
Potential fix for code scanning alert no. 33: Incomplete URL scheme check

### DIFF
--- a/netlify/functions/security-middleware.js
+++ b/netlify/functions/security-middleware.js
@@ -364,6 +364,8 @@ class SecurityMiddleware {
             .replace(/<[^>]*>/g, '')
             .replace(/[<>]/g, '') 
             .replace(/javascript:/gi, '')
+            .replace(/data:/gi, '')
+            .replace(/vbscript:/gi, '')
             .replace(/<script/gi, '') 
             .trim();
     }

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1135,7 +1135,18 @@ class DashboardHandler {
         const hasStyleSrc = cspContent.includes('style-src');
         const hasConnectSrc = cspContent.includes('connect-src');
         const hasFirebaseDomains = cspContent.includes('firebase.googleapis.com') || cspContent.includes('firestore.googleapis.com');
-        const hasGoogleDomains = cspContent.includes('googleapis.com');
+        const allowedGoogleHosts = ['googleapis.com'];
+        const hasGoogleDomains = cspContent.split(';').some(directive => {
+            const urls = directive.split(' ').slice(1); // Skip the directive name (e.g., "default-src").
+            return urls.some(url => {
+                try {
+                    const host = new URL(url).host;
+                    return allowedGoogleHosts.includes(host);
+                } catch {
+                    return false; // Ignore invalid URLs.
+                }
+            });
+        });
         const hasUnsafeInline = cspContent.includes("'unsafe-inline'");
 
         let score = 0;


### PR DESCRIPTION
Potential fix for [https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/33](https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/33)

To fix the problem, we need to extend the `sanitizeString` method to cover `data:` and `vbscript:` URL schemes in addition to `javascript:`. The simplest and most effective approach is to add additional checks for these schemes, similar to the existing check for `javascript:`.

We will modify the `sanitizeString` method to replace occurrences of `data:` and `vbscript:` (case-insensitive) with an empty string, alongside the existing `javascript:` check. This ensures that any potentially harmful URL schemes are sanitized from the input.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
