### PR TITLE
Potential fix for code scanning alert no. 39: Incomplete URL scheme check

### DIFF
--- a/public/js/security.js
+++ b/public/js/security.js
@@ -289,9 +289,9 @@ class SecurityManager {
             .replace(/\0/g, '')
             // Remove control characters except newlines and tabs
             .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
-            // Remove JavaScript protocol
-            .replace(/javascript:/gi, '')
-            // Remove data URLs
+            // Remove JavaScript, data, and vbscript protocols
+            .replace(/(?:javascript:|data:|vbscript:)/gi, '')
+            // Remove data URLs (including text/html)
             .replace(/data:text\/html/gi, '')
             // Normalize whitespace
             .replace(/\s+/g, ' ')


### PR DESCRIPTION
Potential fix for [https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/39](https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/39)

To fix the issue, the sanitization logic should be updated to remove URLs with schemes `data:` and `vbscript:` alongside `javascript:`. These schemes should be handled case-insensitively and trimmed of any preceding whitespace.

**Steps to fix:**
1. Modify the sanitization chain in the `sanitizeInput` method to include checks for `data:` and `vbscript:` schemes.
2. Use a regular expression to remove these schemes, ensuring it matches case-insensitively.
3. Do not alter the existing sanitization functionality beyond introducing these additional checks.

**Required changes:**
- Update the regex used in line 293 to include `data:` and `vbscript:`.
- Ensure the sanitization logic covers all relevant schemes comprehensively.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
