### PR TITLE
Potential fix for code scanning alert no. 36: Incomplete URL substring sanitization

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1136,7 +1136,16 @@ class DashboardHandler {
         const hasConnectSrc = cspContent.includes('connect-src');
         const connectSrcMatches = cspContent.match(/connect-src\s[^;]+/g);
         const connectSrcValues = connectSrcMatches ? connectSrcMatches[0].split(/\s+/).slice(1) : [];
-        const hasFirebaseDomains = connectSrcValues.includes('https://firebase.googleapis.com') || connectSrcValues.includes('https://firestore.googleapis.com');
+        const allowedFirebaseHosts = ['firebase.googleapis.com', 'firestore.googleapis.com'];
+        const hasFirebaseDomains = connectSrcValues.some(url => {
+            try {
+                const parsedUrl = new URL(url);
+                return allowedFirebaseHosts.includes(parsedUrl.host);
+            } catch (e) {
+                console.warn('Invalid URL in connect-src values:', url, e);
+                return false;
+            }
+        });
         const hasGoogleDomains = cspContent.includes('googleapis.com');
         const hasUnsafeInline = cspContent.includes("'unsafe-inline'");
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1134,7 +1134,9 @@ class DashboardHandler {
         const hasScriptSrc = cspContent.includes('script-src');
         const hasStyleSrc = cspContent.includes('style-src');
         const hasConnectSrc = cspContent.includes('connect-src');
-        const hasFirebaseDomains = cspContent.includes('firebase.googleapis.com') || cspContent.includes('firestore.googleapis.com');
+        const connectSrcMatches = cspContent.match(/connect-src\s[^;]+/g);
+        const connectSrcValues = connectSrcMatches ? connectSrcMatches[0].split(/\s+/).slice(1) : [];
+        const hasFirebaseDomains = connectSrcValues.includes('https://firebase.googleapis.com') || connectSrcValues.includes('https://firestore.googleapis.com');
         const hasGoogleDomains = cspContent.includes('googleapis.com');
         const hasUnsafeInline = cspContent.includes("'unsafe-inline'");
 


### PR DESCRIPTION
Potential fix for [https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/36](https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/36)

To address this issue, the CSP content should be parsed and checked for valid hostnames in the appropriate directive (e.g., `connect-src`). Instead of simply checking for `'firebase.googleapis.com'` as a substring, extract and evaluate the relevant parts of the CSP content to verify that the `firebase.googleapis.com` domain is included explicitly and correctly. This involves:
1. Parsing the CSP meta tag's content.
2. Extracting the values of the `connect-src` directive.
3. Verifying that `firebase.googleapis.com` is present as a standalone domain within the allowed sources.

The `cspContent.includes('firebase.googleapis.com')` check will be replaced with a more robust validation mechanism.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
