### PR TITLE
Potential fix for code scanning alert no. 62: Bad HTML filtering regexp

### DIFF
--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 class AuthHandler {
     constructor() {
         if (!window.auth || !window.db) {
@@ -239,14 +240,8 @@ class AuthHandler {
         if (typeof input !== 'string') {
             return String(input).trim();
         }
-        return input
-            .replace(/<[^>]*>/g, '')
-            .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-            .replace(/[<>]/g, '')
-            .replace(/\0/g, '')
-            .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '')
-            .replace(/\s+/g, ' ')
-            .trim();
+        // Use DOMPurify to sanitize the input
+        return DOMPurify.sanitize(input).trim();
     }
     async signInWithGoogle() {
         try {


### PR DESCRIPTION
Potential fix for [https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/62](https://github.com/ThemeHackers/themehackers.github.io/security/code-scanning/62)

The best way to fix the problem is to replace the custom regular expression-based sanitization of `<script>` tags with a well-tested HTML sanitization library like `DOMPurify`. Such libraries are designed to handle the many nuances of HTML parsing and ensure robust protection against cross-site scripting (XSS) attacks. This eliminates the need for brittle regular expressions and provides a comprehensive solution to sanitize user inputs.

To implement this:
1. Install the `DOMPurify` library.
2. Replace the custom sanitization logic in the `sanitizeInput` method with a call to `DOMPurify.sanitize`.
3. Ensure the library is included in the application (import statement or script tag).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
